### PR TITLE
refactor verifyTokenAgainstStacksService for testability and enable related test (plus the branches that preceded it)

### DIFF
--- a/src/edu/stanford/dlss/wowza/SulWowza.java
+++ b/src/edu/stanford/dlss/wowza/SulWowza.java
@@ -301,10 +301,7 @@ public class SulWowza extends ModuleBase
     {
         try
         {
-            HttpURLConnection stacksConn = (HttpURLConnection) verifyStacksTokenUrl.openConnection();
-            stacksConn.setRequestMethod("HEAD");
-            stacksConn.setConnectTimeout(stacksConnectionTimeout * 1000); // need milliseconds
-            stacksConn.setReadTimeout(stacksReadTimeout * 1000);  // need milliseconds
+            HttpURLConnection stacksConn = getStacksUrlConn(verifyStacksTokenUrl, "HEAD");
             stacksConn.connect();
             int status = stacksConn.getResponseCode();
             getLogger().info(this.getClass().getSimpleName() + " sent verify_token request to " + verifyStacksTokenUrl);
@@ -325,5 +322,14 @@ public class SulWowza extends ModuleBase
             getLogger().error(this.getClass().getSimpleName() + " unable to verify stacks token at " + verifyStacksTokenUrl + e);
         }
         return false;
+    }
+
+    HttpURLConnection getStacksUrlConn(URL stacksUrl, String requestMethod) throws IOException
+    {
+        HttpURLConnection stacksConn = (HttpURLConnection) stacksUrl.openConnection();
+        stacksConn.setRequestMethod(requestMethod);
+        stacksConn.setConnectTimeout(stacksConnectionTimeout * 1000); // need milliseconds
+        stacksConn.setReadTimeout(stacksReadTimeout * 1000);  // need milliseconds
+        return stacksConn;
     }
 }


### PR DESCRIPTION
- pull URL connection creation out of verifyTokenAgainstStacksService and into helper method.
- enable verifyTokenAgainstStacksService_wUrlString_logsRequestMade, tweaks to mocking and expectations to conform with updated plugin code.

since this is against `authzn`, it'd obviate the need to merge `autzn-suggestions` if you agree with this (the other one felt less controversial, hence its being implemented first).

connected to #5
