### PR TITLE
have getVerifyStacksTokenUrl encode URL components, add a test (plus the branches that preceded it)

### DIFF
--- a/src/edu/stanford/dlss/wowza/SulWowza.java
+++ b/src/edu/stanford/dlss/wowza/SulWowza.java
@@ -301,10 +301,7 @@ public class SulWowza extends ModuleBase
     {
         try
         {
-            HttpURLConnection stacksConn = (HttpURLConnection) verifyStacksTokenUrl.openConnection();
-            stacksConn.setRequestMethod("HEAD");
-            stacksConn.setConnectTimeout(stacksConnectionTimeout * 1000); // need milliseconds
-            stacksConn.setReadTimeout(stacksReadTimeout * 1000);  // need milliseconds
+            HttpURLConnection stacksConn = getStacksUrlConn(verifyStacksTokenUrl, "HEAD");
             stacksConn.connect();
             int status = stacksConn.getResponseCode();
             getLogger().info(this.getClass().getSimpleName() + " sent verify_token request to " + verifyStacksTokenUrl);
@@ -325,5 +322,14 @@ public class SulWowza extends ModuleBase
             getLogger().error(this.getClass().getSimpleName() + " unable to verify stacks token at " + verifyStacksTokenUrl + e);
         }
         return false;
+    }
+
+    HttpURLConnection getStacksUrlConn(URL stacksUrl, String requestMethod) throws IOException
+    {
+        HttpURLConnection stacksConn = (HttpURLConnection) stacksUrl.openConnection();
+        stacksConn.setRequestMethod(requestMethod);
+        stacksConn.setConnectTimeout(stacksConnectionTimeout * 1000); // need milliseconds
+        stacksConn.setReadTimeout(stacksReadTimeout * 1000);  // need milliseconds
+        return stacksConn;
     }
 }

--- a/src/edu/stanford/dlss/wowza/SulWowza.java
+++ b/src/edu/stanford/dlss/wowza/SulWowza.java
@@ -283,8 +283,8 @@ public class SulWowza extends ModuleBase
     URL getVerifyStacksTokenUrl(String stacksToken, String druid, String filename, String userIp)
     {
         // TODO:  Url encode anything?   utf-8 charset affect anything? (filename, stacksToken)
-        String queryStr = "stacks_token=" + stacksToken + "&user_ip=" + userIp;
-        String fullUrl = stacksTokenVerificationBaseUrl + "/media/" + druid + "/" + filename + "/verify_token?" + queryStr;
+        String queryStr = "stacks_token=" + urlEncode(stacksToken) + "&user_ip=" + urlEncode(userIp);
+        String fullUrl = stacksTokenVerificationBaseUrl + "/media/" + urlEncode(druid) + "/" + urlEncode(filename) + "/verify_token?" + queryStr;
         try
         {
             return new URL(fullUrl);
@@ -331,5 +331,19 @@ public class SulWowza extends ModuleBase
         stacksConn.setConnectTimeout(stacksConnectionTimeout * 1000); // need milliseconds
         stacksConn.setReadTimeout(stacksReadTimeout * 1000);  // need milliseconds
         return stacksConn;
+    }
+
+    static String urlEncode(String urlComponent)
+    {
+        try
+        {
+            // the javadocs say that encode without an explicitly specified encoding is deprecated
+            return URLEncoder.encode(urlComponent, java.nio.charset.StandardCharsets.UTF_8.toString());
+        }
+        catch (java.io.UnsupportedEncodingException e)
+        {
+            getLogger().error(SulWowza.class.getSimpleName() + " this should never happen, since we should be using the JDK UTF-8 constant: " + urlComponent + " ; " + e);
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/test/edu/stanford/dlss/wowza/TestSulWowza.java
+++ b/test/edu/stanford/dlss/wowza/TestSulWowza.java
@@ -735,6 +735,45 @@ public class TestSulWowza
     }
 
     @Test
+    public void verifyTokenAgainstStacksService_filenameNeedsEncoding()
+    {
+        WMSProperties mockProperties = mock(WMSProperties.class);
+        when(mockProperties.getPropertyStr(anyString(), anyString())).thenReturn(SulWowza.DEFAULT_STACKS_TOKEN_VERIFICATION_BASEURL);
+        IApplicationInstance appInstanceMock = mock(IApplicationInstance.class);
+        when(appInstanceMock.getProperties()).thenReturn(mockProperties);
+        testModule.onAppStart(appInstanceMock);
+        String druid = "oo000oo0000";
+        String filename = "file name with spaces; and an unusual char @ then end.ext!";
+        String userIp = "0.0.0.0";
+        String expPath = "/media/" + druid + "/" + SulWowza.urlEncode(filename) + "/verify_token";
+        String expQueryStr = "?stacks_token=" + stacksToken + "&user_ip=" + userIp;
+        String expUrlStr = SulWowza.DEFAULT_STACKS_TOKEN_VERIFICATION_BASEURL + expPath + expQueryStr;
+
+        URL resultUrl = testModule.getVerifyStacksTokenUrl(stacksToken, druid, filename, userIp);
+        assertEquals(expUrlStr, resultUrl.toString());
+    }
+
+    @Test
+    public void verifyTokenAgainstStacksService_stacksTokenNeedsEncoding()
+    {
+        WMSProperties mockProperties = mock(WMSProperties.class);
+        when(mockProperties.getPropertyStr(anyString(), anyString())).thenReturn(SulWowza.DEFAULT_STACKS_TOKEN_VERIFICATION_BASEURL);
+        IApplicationInstance appInstanceMock = mock(IApplicationInstance.class);
+        when(appInstanceMock.getProperties()).thenReturn(mockProperties);
+        testModule.onAppStart(appInstanceMock);
+        String druid = "oo000oo0000";
+        String filename = "filename.ext";
+        String userIp = "0.0.0.0";
+        String expPath = "/media/" + druid + "/" + filename + "/verify_token";
+        String stacksTokenWithWeirdChars = "ü!@#$%^&--*()~`=+%20_";
+        String expQueryStr = "?stacks_token=" + SulWowza.urlEncode(stacksTokenWithWeirdChars) + "&user_ip=" + userIp;
+        String expUrlStr = SulWowza.DEFAULT_STACKS_TOKEN_VERIFICATION_BASEURL + expPath + expQueryStr;
+
+        URL resultUrl = testModule.getVerifyStacksTokenUrl(stacksTokenWithWeirdChars, druid, filename, userIp);
+        assertEquals(expUrlStr, resultUrl.toString());
+    }
+
+    @Test
     /** expect it to return null and log an error message */
     public void verifyTokenAgainstStacksService_malformedUrl()
     {


### PR DESCRIPTION
alright, couldn't resist, here's an attempt at doing URL encoding for the stacks verification URL.  not totally naive, since it follows the suggestion to avoid the deprecated old version of encode.

also includes the things that i was more sure about (method name swaps, token verification refactoring), and so would supersede those two PRs if it were merged.

connected to #9
