### PR TITLE
User ip addr validation and retrieval

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,10 @@ plugins {
     id 'org.ajoberstar.grgit' version '1.4.2'
 }
 
+dependencies {
+    compile group: 'commons-validator', name: 'commons-validator', version: '1.5.1'
+}
+
 import org.ajoberstar.grgit.Grgit
 def grgit = Grgit.open(project.rootDir)
 

--- a/src/edu/stanford/dlss/wowza/SulWowza.java
+++ b/src/edu/stanford/dlss/wowza/SulWowza.java
@@ -8,6 +8,7 @@ import java.util.regex.Pattern;
 
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
+import org.apache.commons.validator.routines.InetAddressValidator;
 import com.wowza.wms.application.IApplicationInstance;
 import com.wowza.wms.httpstreamer.cupertinostreaming.httpstreamer.HTTPStreamerSessionCupertino;
 import com.wowza.wms.httpstreamer.model.IHTTPStreamerSession;
@@ -210,12 +211,23 @@ public class SulWowza extends ModuleBase
         }
     }
 
-    private static final int MIN_IP_LENGTH = "1.1.1.1".length();
+    boolean isValidInetAddr(String inetAddress)
+    {
+        return InetAddressValidator.getInstance().isValid(inetAddress);
+    }
+
+    /** it's possible for something like "1.1" or "1" to be a valid IP address, but we want a full four octet address.
+      * this implicitly restricts us to IPv4 for now, though that seems like a safe assumption at the moment.
+      * see also: http://docs.oracle.com/javase/6/docs/api/java/net/Inet4Address.html#format
+     */
+    boolean isDottedQuadString(String ipAddr)
+    {
+        return ipAddr.matches("\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}");
+    }
 
     boolean validateUserIp(String userIp)
     {
-        // could validate it's an IP address format, but since we obtain it from http session, we trust it
-        if (userIp != null && userIp.length() >= MIN_IP_LENGTH)
+        if (userIp != null && isValidInetAddr(userIp) && isDottedQuadString(userIp))
             return true;
         else
         {

--- a/src/edu/stanford/dlss/wowza/SulWowza.java
+++ b/src/edu/stanford/dlss/wowza/SulWowza.java
@@ -231,7 +231,7 @@ public class SulWowza extends ModuleBase
             return true;
         else
         {
-            getLogger().error(this.getClass().getSimpleName() + ": User IP missing or implausibly short" +
+            getLogger().error(this.getClass().getSimpleName() + ": User IP missing or invalid" +
                                 (userIp == null ? "" : ": " + userIp));
             return false;
         }

--- a/test/edu/stanford/dlss/wowza/TestSulWowza.java
+++ b/test/edu/stanford/dlss/wowza/TestSulWowza.java
@@ -314,7 +314,7 @@ public class TestSulWowza
         String filename = "ignored";
         String streamName = "oo/000/oo/0000/" + filename;
         String druid = "oo000oo0000";
-        String userIp = "ignored";
+        String userIp = "1.1.1.1";
         IHTTPStreamerSession sessionMock = mock(IHTTPStreamerSession.class);
         Map<String, String> mockHttpHeaderMap = new HashMap<String, String>();
         mockHttpHeaderMap.put("x-forwarded-for", userIp);

--- a/test/edu/stanford/dlss/wowza/TestSulWowza.java
+++ b/test/edu/stanford/dlss/wowza/TestSulWowza.java
@@ -317,7 +317,8 @@ public class TestSulWowza
         String userIp = "1.1.1.1";
         IHTTPStreamerSession sessionMock = mock(IHTTPStreamerSession.class);
         Map<String, String> mockHttpHeaderMap = new HashMap<String, String>();
-        mockHttpHeaderMap.put("x-forwarded-for", userIp);
+        String xForwardedFor = "1.1.1.1, 2.2.2.2, 3.3.3.3";
+        mockHttpHeaderMap.put("x-forwarded-for", xForwardedFor);
         when(sessionMock.getHTTPHeaderMap()).thenReturn(mockHttpHeaderMap);
         when(sessionMock.getQueryStr()).thenReturn(queryStr);
         when(sessionMock.getStreamName()).thenReturn(streamName);

--- a/test/edu/stanford/dlss/wowza/TestSulWowza.java
+++ b/test/edu/stanford/dlss/wowza/TestSulWowza.java
@@ -626,9 +626,9 @@ public class TestSulWowza
     }
 
     @Test
-    public void validateUserIp_shortString()
+    public void validateUserIp_tooFewOctets()
     {
-        assertFalse(testModule.validateUserIp("short"));
+        assertFalse(testModule.validateUserIp("1.1.1"));
     }
 
     @Test
@@ -643,13 +643,13 @@ public class TestSulWowza
 
         try
         {
-            String shortIp = "short";
-            testModule.validateUserIp(shortIp);
+            String invalidIp = "invalid.ip";
+            testModule.validateUserIp(invalidIp);
             String logMsg = out.toString();
             assertThat(logMsg, allOf(containsString("ERROR"),
                                      containsString(testModule.getClass().getSimpleName()),
-                                     containsString("User IP missing or implausibly short"),
-                                     containsString(shortIp)));
+                                     containsString("User IP missing or invalid"),
+                                     containsString(invalidIp)));
         }
         finally
         {


### PR DESCRIPTION
- instead of using the x-forwarded-for header as-is, parse it as a comma-delimited string and use the first element of the resulting array as the user's IP address
- use InetAddressValidator for more robust IP address validation
- fix tests accordingly
- bump version

maybe commits 1&2 and 3&4 should be collapsed?  i.e., maybe 653f22b and 3219d0d should be a single commit, and likewise for 37030c2 and 37030c2?  happy to squash if others would prefer that.

@tingulfsen @ndushay
