### PR TITLE
properly encode spaces when making requests to stacks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@ plugins {
 }
 
 dependencies {
-    compile group: 'commons-validator', name: 'commons-validator', version: '1.5.1'
-    compile group: 'com.google.guava', name: 'guava', version: '19.0'
+    compile group: 'commons-validator', name: 'commons-validator', version: '1.5.1' // IP address validation
+    compile group: 'com.google.guava', name: 'guava', version: '19.0' // URL escaping
 }
 
 import org.ajoberstar.grgit.Grgit

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ plugins {
 
 dependencies {
     compile group: 'commons-validator', name: 'commons-validator', version: '1.5.1'
+    compile group: 'com.google.guava', name: 'guava', version: '19.0'
 }
 
 import org.ajoberstar.grgit.Grgit

--- a/src/edu/stanford/dlss/wowza/SulWowza.java
+++ b/src/edu/stanford/dlss/wowza/SulWowza.java
@@ -314,7 +314,6 @@ public class SulWowza extends ModuleBase
     /** Assumption: stacksToken, druid, userIp and filename are all reasonable values (non-null, not empty, etc.) */
     URL getVerifyStacksTokenUrl(String stacksToken, String druid, String filename, String userIp)
     {
-        // TODO:  Url encode anything?   utf-8 charset affect anything? (filename, stacksToken)
         String queryStr = "stacks_token=" + escapeFormParam(stacksToken) + "&user_ip=" + escapeFormParam(userIp);
         String fullUrl = stacksTokenVerificationBaseUrl + "/media/" +
                         escapePathSegment(druid) + "/" + escapePathSegment(filename) +

--- a/test/edu/stanford/dlss/wowza/TestSulWowza.java
+++ b/test/edu/stanford/dlss/wowza/TestSulWowza.java
@@ -765,9 +765,11 @@ public class TestSulWowza
         when(appInstanceMock.getProperties()).thenReturn(mockProperties);
         testModule.onAppStart(appInstanceMock);
         String druid = "oo000oo0000";
-        String filename = "{([special-chars])}: ü@?;=&#$%20^*.|-_+!,~'\"`";
+        String filename = "{([special-chars])}: ü@?;=&#$%20^*.|-_+!,~'/\"`";
         String userIp = "0.0.0.0";
-        String expPath = "/media/" + druid + "/" + SulWowza.urlEncode(filename) + "/verify_token";
+        // specifically list the expected encodings, as we've run into trouble with encoding methods that were encoding in unexpected ways
+        String encodedFilename = "%7B%28%5Bspecial-chars%5D%29%7D%3A%20%C3%BC%40%3F%3B%3D%26%23%24%2520%5E%2A.%7C-_%2B%21%2C~%27%2F%22%60";
+        String expPath = "/media/" + druid + "/" + encodedFilename + "/verify_token";
         String expQueryStr = "?stacks_token=" + stacksToken + "&user_ip=" + userIp;
         String expUrlStr = SulWowza.DEFAULT_STACKS_TOKEN_VERIFICATION_BASEURL + expPath + expQueryStr;
 
@@ -787,8 +789,10 @@ public class TestSulWowza
         String filename = "filename.ext";
         String userIp = "0.0.0.0";
         String expPath = "/media/" + druid + "/" + filename + "/verify_token";
-        String stacksTokenWithWeirdChars = "{([special-chars])}: ü@?;=&#$%20^*.|-_+!,~'\"`";
-        String expQueryStr = "?stacks_token=" + SulWowza.urlEncode(stacksTokenWithWeirdChars) + "&user_ip=" + userIp;
+        String stacksTokenWithWeirdChars = "{([special-chars])}: ü@?;=&#$%20^*.|-_+!,~'/\"`";
+        // specifically list the expected encodings, as we've run into trouble with encoding methods that were encoding in unexpected ways
+        String encodedToken = "%7B%28%5Bspecial-chars%5D%29%7D%3A+%C3%BC%40%3F%3B%3D%26%23%24%2520%5E%2A.%7C-_%2B%21%2C~%27%2F%22%60";
+        String expQueryStr = "?stacks_token=" + encodedToken + "&user_ip=" + userIp;
         String expUrlStr = SulWowza.DEFAULT_STACKS_TOKEN_VERIFICATION_BASEURL + expPath + expQueryStr;
 
         URL resultUrl = testModule.getVerifyStacksTokenUrl(stacksTokenWithWeirdChars, druid, filename, userIp);


### PR DESCRIPTION
use "+" in form params, and use "%20" in path segments.

adds a dependency on google's guava package, which provides more general percent escaping than the JDK.  use that to escape things correctly, and use the new package for both types of escaping so as to be consistent (even though JDK can do form params).  add explanatory comment, make tests more explicit.

closes #28
