### PR TITLE
add example log4j.properties files to example

### DIFF
--- a/conf/example/log4j.properties
+++ b/conf/example/log4j.properties
@@ -1,0 +1,88 @@
+# see log4j.properties.orig for more logging options
+
+# We are using APPLICATION level logging, except for console and serverStats
+
+# The logging context is
+#log4j.logger.[vhost].[application].[appInstance]
+
+# Field list
+#date,time,tz,x-event,x-category,x-severity,x-status,x-ctx,x-comment,x-vhost,x-app,x-appinst,x-duration,s-ip,s-port,s-uri,c-ip,c-proto,c-referrer,c-user-agent,c-client-id,cs-bytes,sc-bytes,x-stream-id,x-spos,cs-stream-bytes,sc-stream-bytes,x-sname,x-sname-query,x-file-name,x-file-ext,x-file-size,x-file-length,x-suri,x-suri-stem,x-suri-query,cs-uri-stem,cs-uri-query
+
+# Category list
+#server,vhost,application,session,stream,rtsp
+
+# Event list
+#connect-pending,connect,disconnect,publish,unpublish,play,pause,setbuffertime,create,destroy,setstreamtype,unpause,seek,stop,record,recordstop,server-start,server-stop,vhost-start,vhost-stop,app-start,app-stop,comment,announce
+
+# To force UTF-8 encoding of log values add the following property to the appender definition (where [appender] is the name of the appender such as "stdout" or "R")
+#log4j.appender.[appender].encoding=UTF-8
+
+log4j.rootCategory=INFO, stdout, serverAccess, serverError
+
+# Console appender
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=com.wowza.wms.logging.ECLFPatternLayout
+log4j.appender.stdout.layout.Fields=x-severity,x-category,x-event,x-ctx,x-comment
+log4j.appender.stdout.layout.OutputHeader=false
+log4j.appender.stdout.layout.QuoteFields=false
+log4j.appender.stdout.layout.Delimiter=space
+
+# Access appender
+log4j.appender.serverAccess=org.apache.log4j.DailyRollingFileAppender
+log4j.appender.serverAccess.encoding=UTF-8
+log4j.appender.serverAccess.DatePattern='.'yyyy-MM-dd
+log4j.appender.serverAccess.File=${com.wowza.wms.ConfigHome}/logs/wowzastreamingengine_access.log
+log4j.appender.serverAccess.layout=com.wowza.wms.logging.ECLFPatternLayout
+log4j.appender.serverAccess.layout.Fields=date,time,x-app,x-severity,x-status,c-proto,x-category,x-event,x-ctx,x-comment,x-sname,x-file-name,x-file-ext,x-suri,c-ip,c-client-id,c-referrer,c-user-agent,s-uri,x-stream-id,x-file-size,x-file-length,sc-bytes,sc-stream-bytes,x-spos,x-duration
+#log4j.appender.serverAccess.layout.Fields=date,time,tz,x-event,x-category,x-severity,x-status,x-ctx,x-comment,x-vhost,x-app,x-appinst,x-duration,s-ip,s-port,s-uri,c-ip,c-proto,c-referrer,c-user-agent,c-client-id,cs-bytes,sc-bytes,x-stream-id,x-spos,cs-stream-bytes,sc-stream-bytes,x-sname,x-sname-query,x-file-name,x-file-ext,x-file-size,x-file-length,x-suri,x-suri-stem,x-suri-query,cs-uri-stem,cs-uri-query
+log4j.appender.serverAccess.layout.OutputHeader=true
+log4j.appender.serverAccess.layout.QuoteFields=false
+log4j.appender.serverAccess.layout.Delimiter=tab
+
+# Error appender
+log4j.appender.serverError=org.apache.log4j.DailyRollingFileAppender
+log4j.appender.serverError.encoding=UTF-8
+log4j.appender.serverError.DatePattern='.'yyyy-MM-dd
+log4j.appender.serverError.File=${com.wowza.wms.ConfigHome}/logs/wowzastreamingengine_error.log
+log4j.appender.serverError.layout=com.wowza.wms.logging.ECLFPatternLayout
+log4j.appender.serverError.layout.Fields=date,time,x-app,x-severity,x-status,c-proto,x-category,x-event,x-ctx,x-comment,x-sname,x-file-name,x-file-ext,x-suri,c-ip,c-client-id,c-referrer,c-user-agent,s-uri,x-stream-id,x-file-size,x-file-length,sc-bytes,sc-stream-bytes,x-spos,x-duration
+#log4j.appender.serverError.layout.Fields=x-severity,x-category,x-event;date,time,c-client-id,c-ip,c-port,cs-bytes,sc-bytes,x-duration,x-sname,x-stream-id,x-spos,sc-stream-bytes,cs-stream-bytes,x-file-size,x-file-length,x-ctx,x-comment
+log4j.appender.serverError.layout.OutputHeader=true
+log4j.appender.serverError.layout.QuoteFields=false
+log4j.appender.serverError.layout.Delimiter=tab
+log4j.appender.serverError.Threshold=WARN
+
+# Below are logging definitions for dynamic log file generation on a per application basis.
+# It will generate log files using the following directory/file structure:
+#
+#   [install-dir]/logs/[application]/wowzastreamingengine_access.log
+#   [install-dir]/logs/[application]/wowzastreamingengine_error.log
+#   [install-dir]/logs/[application]/wowzastreamingengine_stats.log
+
+#### APPLICATION LEVEL LOGGING CONFIG - START ####
+log4j.logger.${com.wowza.wms.context.VHost}.${com.wowza.wms.context.Application}=INFO, ${com.wowza.wms.context.Application}_access, ${com.wowza.wms.context.Application}_error
+
+# Access appender
+log4j.appender.${com.wowza.wms.context.Application}_access=org.apache.log4j.DailyRollingFileAppender
+log4j.appender.${com.wowza.wms.context.Application}_access.DatePattern='.'yyyy-MM-dd
+log4j.appender.${com.wowza.wms.context.Application}_access.encoding=UTF-8
+log4j.appender.${com.wowza.wms.context.Application}_access.File=${com.wowza.wms.ConfigHome}/logs/${com.wowza.wms.context.Application}/wowzastreamingengine_access.log
+log4j.appender.${com.wowza.wms.context.Application}_access.layout=com.wowza.wms.logging.ECLFPatternLayout
+log4j.appender.${com.wowza.wms.context.Application}_access.layout.Fields=date,time,x-app,x-severity,x-status,c-proto,x-category,x-event,x-ctx,x-comment,x-sname,x-file-name,x-file-ext,x-suri,c-ip,c-client-id,c-referrer,c-user-agent,s-uri,x-stream-id,x-file-size,x-file-length,sc-bytes,sc-stream-bytes,x-spos,x-duration
+#log4j.appender.${com.wowza.wms.context.VHost}_${com.wowza.wms.context.Application}_access.layout.Fields=x-severity,x-category,x-event;date,time,c-client-id,c-ip,c-port,cs-bytes,sc-bytes,x-duration,x-sname,x-stream-id,x-spos,sc-stream-bytes,cs-stream-bytes,x-file-size,x-file-length,x-ctx,x-comment
+log4j.appender.${com.wowza.wms.context.Application}_access.layout.OutputHeader=true
+log4j.appender.${com.wowza.wms.context.Application}_access.layout.QuoteFields=false
+log4j.appender.${com.wowza.wms.context.Application}_access.layout.Delimiter=tab
+
+# Error appender
+log4j.appender.${com.wowza.wms.context.Application}_error=org.apache.log4j.DailyRollingFileAppender
+log4j.appender.${com.wowza.wms.context.Application}_error.DatePattern='.'yyyy-MM-dd
+log4j.appender.${com.wowza.wms.context.Application}_error.encoding=UTF-8
+log4j.appender.${com.wowza.wms.context.Application}_error.File=${com.wowza.wms.ConfigHome}/logs/${com.wowza.wms.context.Application}/wowzastreamingengine_error.log
+log4j.appender.${com.wowza.wms.context.Application}_error.layout=com.wowza.wms.logging.ECLFPatternLayout
+log4j.appender.${com.wowza.wms.context.Application}_error.layout.Fields=date,time,x-app,x-severity,x-status,c-proto,x-category,x-event,x-ctx,x-comment,x-sname,x-file-name,x-file-ext,x-suri,c-ip,c-client-id,c-referrer,c-user-agent,s-uri,x-stream-id,x-file-size,x-file-length,sc-bytes,sc-stream-bytes,x-spos,x-duration
+#log4j.appender.${com.wowza.wms.context.VHost}_${com.wowza.wms.context.Application}_error.layout.Fields=x-severity,x-category,x-event;date,time,c-client-id,c-ip,c-port,cs-bytes,sc-bytes,x-duration,x-sname,x-stream-id,x-spos,sc-stream-bytes,cs-stream-bytes,x-file-size,x-file-length,x-ctx,x-comment
+log4j.appender.${com.wowza.wms.context.Application}_error.layout.OutputHeader=true
+log4j.appender.${com.wowza.wms.context.Application}_error.layout.QuoteFields=false
+log4j.appender.${com.wowza.wms.context.Application}_error.layout.Delimiter=tab
+log4j.appender.${com.wowza.wms.context.Application}_error.Threshold=WARN

--- a/conf/example/log4j.properties
+++ b/conf/example/log4j.properties
@@ -1,12 +1,17 @@
 # see log4j.properties.orig for more logging options
 
-# We are using APPLICATION level logging, except for console and serverStats
+# We are using APPLICATION level logging
+
+# NOTE: From http://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/DailyRollingFileAppender.html, we get:
+# "DailyRollingFileAppender has been observed to exhibit synchronization issues and data loss. The log4j extras companion includes alternatives which should be considered for new deployments and which are discussed in the documentation for org.apache.log4j.rolling.RollingFileAppender."
+#
+# Plus the current release of log4j is 2, but wowza ships with 1.2.17.
 
 # The logging context is
 #log4j.logger.[vhost].[application].[appInstance]
 
 # Field list
-#date,time,tz,x-event,x-category,x-severity,x-status,x-ctx,x-comment,x-vhost,x-app,x-appinst,x-duration,s-ip,s-port,s-uri,c-ip,c-proto,c-referrer,c-user-agent,c-client-id,cs-bytes,sc-bytes,x-stream-id,x-spos,cs-stream-bytes,sc-stream-bytes,x-sname,x-sname-query,x-file-name,x-file-ext,x-file-size,x-file-length,x-suri,x-suri-stem,x-suri-query,cs-uri-stem,cs-uri-query
+#date,time,tz,x-event,x-category,x-severity,x-status,x-ctx,x-comment,x-vhost,x-app,x-appinst,x-duration,s-ip,s-proto,s-uri,c-ip,c-proto,c-referrer,c-user-agent,c-client-id,cs-bytes,sc-bytes,x-stream-id,x-spos,cs-stream-bytes,sc-stream-bytes,x-sname,x-sname-query,x-file-name,x-file-ext,x-file-size,x-file-length,x-suri,x-suri-stem,x-suri-query,cs-uri-stem,cs-uri-query
 
 # Category list
 #server,vhost,application,session,stream,rtsp

--- a/conf/example/log4j.properties
+++ b/conf/example/log4j.properties
@@ -17,8 +17,7 @@
 # To force UTF-8 encoding of log values add the following property to the appender definition (where [appender] is the name of the appender such as "stdout" or "R")
 #log4j.appender.[appender].encoding=UTF-8
 
-#log4j.rootCategory=INFO, stdout, serverAccess, serverError
-log4j.rootCategory=INFO, stdout
+log4j.rootCategory=INFO, stdout, serverAccess, serverError
 
 # Console appender
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender

--- a/conf/example/log4j.properties
+++ b/conf/example/log4j.properties
@@ -1,26 +1,15 @@
-# see log4j.properties.orig for more logging options
+# for more info, see Wowza User's Guide and log4j.properties.orig
 
-# We are using APPLICATION level logging
+# We are using application level logging as well as root level logging
+#  in order to be sure we capture log messages above the application level (e.g. server level).
+# The logging context is:  log4j.logger.[vhost].[application].[appInstance]
 
 # NOTE: From http://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/DailyRollingFileAppender.html, we get:
-# "DailyRollingFileAppender has been observed to exhibit synchronization issues and data loss. The log4j extras companion includes alternatives which should be considered for new deployments and which are discussed in the documentation for org.apache.log4j.rolling.RollingFileAppender."
+# "DailyRollingFileAppender has been observed to exhibit synchronization issues and data loss.
+# The log4j extras companion includes alternatives which should be considered for new deployments and
+# which are discussed in the documentation for org.apache.log4j.rolling.RollingFileAppender."
 #
 # Plus the current release of log4j is 2, but wowza ships with 1.2.17.
-
-# The logging context is
-#log4j.logger.[vhost].[application].[appInstance]
-
-# Field list
-#date,time,tz,x-event,x-category,x-severity,x-status,x-ctx,x-comment,x-vhost,x-app,x-appinst,x-duration,s-ip,s-proto,s-uri,c-ip,c-proto,c-referrer,c-user-agent,c-client-id,cs-bytes,sc-bytes,x-stream-id,x-spos,cs-stream-bytes,sc-stream-bytes,x-sname,x-sname-query,x-file-name,x-file-ext,x-file-size,x-file-length,x-suri,x-suri-stem,x-suri-query,cs-uri-stem,cs-uri-query
-
-# Category list
-#server,vhost,application,session,stream,rtsp
-
-# Event list
-#connect-pending,connect,disconnect,publish,unpublish,play,pause,setbuffertime,create,destroy,setstreamtype,unpause,seek,stop,record,recordstop,server-start,server-stop,vhost-start,vhost-stop,app-start,app-stop,comment,announce
-
-# To force UTF-8 encoding of log values add the following property to the appender definition (where [appender] is the name of the appender such as "stdout" or "R")
-#log4j.appender.[appender].encoding=UTF-8
 
 log4j.rootCategory=INFO, stdout, serverAccess, serverError
 
@@ -39,7 +28,6 @@ log4j.appender.serverAccess.DatePattern='.'yyyy-MM-dd
 log4j.appender.serverAccess.File=${com.wowza.wms.ConfigHome}/logs/wowzastreamingengine_access.log
 log4j.appender.serverAccess.layout=com.wowza.wms.logging.ECLFPatternLayout
 log4j.appender.serverAccess.layout.Fields=date,time,x-app,x-severity,x-status,c-proto,x-category,x-event,x-ctx,x-comment,x-sname,x-file-name,x-file-ext,x-suri,c-ip,c-client-id,c-referrer,c-user-agent,s-uri,x-stream-id,x-file-size,x-file-length,sc-bytes,sc-stream-bytes,x-spos,x-duration
-#log4j.appender.serverAccess.layout.Fields=date,time,tz,x-event,x-category,x-severity,x-status,x-ctx,x-comment,x-vhost,x-app,x-appinst,x-duration,s-ip,s-port,s-uri,c-ip,c-proto,c-referrer,c-user-agent,c-client-id,cs-bytes,sc-bytes,x-stream-id,x-spos,cs-stream-bytes,sc-stream-bytes,x-sname,x-sname-query,x-file-name,x-file-ext,x-file-size,x-file-length,x-suri,x-suri-stem,x-suri-query,cs-uri-stem,cs-uri-query
 log4j.appender.serverAccess.layout.OutputHeader=true
 log4j.appender.serverAccess.layout.QuoteFields=false
 log4j.appender.serverAccess.layout.Delimiter=tab
@@ -51,20 +39,16 @@ log4j.appender.serverError.DatePattern='.'yyyy-MM-dd
 log4j.appender.serverError.File=${com.wowza.wms.ConfigHome}/logs/wowzastreamingengine_error.log
 log4j.appender.serverError.layout=com.wowza.wms.logging.ECLFPatternLayout
 log4j.appender.serverError.layout.Fields=date,time,x-app,x-severity,x-status,c-proto,x-category,x-event,x-ctx,x-comment,x-sname,x-file-name,x-file-ext,x-suri,c-ip,c-client-id,c-referrer,c-user-agent,s-uri,x-stream-id,x-file-size,x-file-length,sc-bytes,sc-stream-bytes,x-spos,x-duration
-#log4j.appender.serverError.layout.Fields=x-severity,x-category,x-event;date,time,c-client-id,c-ip,c-port,cs-bytes,sc-bytes,x-duration,x-sname,x-stream-id,x-spos,sc-stream-bytes,cs-stream-bytes,x-file-size,x-file-length,x-ctx,x-comment
 log4j.appender.serverError.layout.OutputHeader=true
 log4j.appender.serverError.layout.QuoteFields=false
 log4j.appender.serverError.layout.Delimiter=tab
 log4j.appender.serverError.Threshold=WARN
 
-# Below are logging definitions for dynamic log file generation on a per application basis.
-# It will generate log files using the following directory/file structure:
-#
-#   [install-dir]/logs/[application]/wowzastreamingengine_access.log
-#   [install-dir]/logs/[application]/wowzastreamingengine_error.log
-#   [install-dir]/logs/[application]/wowzastreamingengine_stats.log
 
 #### APPLICATION LEVEL LOGGING CONFIG - START ####
+# It will generate log files using the following directory/file structure:
+#   [install-dir]/logs/[application]/wowzastreamingengine_access.log
+#   [install-dir]/logs/[application]/wowzastreamingengine_error.log
 log4j.logger.${com.wowza.wms.context.VHost}.${com.wowza.wms.context.Application}=INFO, ${com.wowza.wms.context.Application}_access, ${com.wowza.wms.context.Application}_error
 
 # Access appender
@@ -74,7 +58,6 @@ log4j.appender.${com.wowza.wms.context.Application}_access.encoding=UTF-8
 log4j.appender.${com.wowza.wms.context.Application}_access.File=${com.wowza.wms.ConfigHome}/logs/${com.wowza.wms.context.Application}/wowzastreamingengine_access.log
 log4j.appender.${com.wowza.wms.context.Application}_access.layout=com.wowza.wms.logging.ECLFPatternLayout
 log4j.appender.${com.wowza.wms.context.Application}_access.layout.Fields=date,time,x-app,x-severity,x-status,c-proto,x-category,x-event,x-ctx,x-comment,x-sname,x-file-name,x-file-ext,x-suri,c-ip,c-client-id,c-referrer,c-user-agent,s-uri,x-stream-id,x-file-size,x-file-length,sc-bytes,sc-stream-bytes,x-spos,x-duration
-#log4j.appender.${com.wowza.wms.context.VHost}_${com.wowza.wms.context.Application}_access.layout.Fields=x-severity,x-category,x-event;date,time,c-client-id,c-ip,c-port,cs-bytes,sc-bytes,x-duration,x-sname,x-stream-id,x-spos,sc-stream-bytes,cs-stream-bytes,x-file-size,x-file-length,x-ctx,x-comment
 log4j.appender.${com.wowza.wms.context.Application}_access.layout.OutputHeader=true
 log4j.appender.${com.wowza.wms.context.Application}_access.layout.QuoteFields=false
 log4j.appender.${com.wowza.wms.context.Application}_access.layout.Delimiter=tab
@@ -86,7 +69,6 @@ log4j.appender.${com.wowza.wms.context.Application}_error.encoding=UTF-8
 log4j.appender.${com.wowza.wms.context.Application}_error.File=${com.wowza.wms.ConfigHome}/logs/${com.wowza.wms.context.Application}/wowzastreamingengine_error.log
 log4j.appender.${com.wowza.wms.context.Application}_error.layout=com.wowza.wms.logging.ECLFPatternLayout
 log4j.appender.${com.wowza.wms.context.Application}_error.layout.Fields=date,time,x-app,x-severity,x-status,c-proto,x-category,x-event,x-ctx,x-comment,x-sname,x-file-name,x-file-ext,x-suri,c-ip,c-client-id,c-referrer,c-user-agent,s-uri,x-stream-id,x-file-size,x-file-length,sc-bytes,sc-stream-bytes,x-spos,x-duration
-#log4j.appender.${com.wowza.wms.context.VHost}_${com.wowza.wms.context.Application}_error.layout.Fields=x-severity,x-category,x-event;date,time,c-client-id,c-ip,c-port,cs-bytes,sc-bytes,x-duration,x-sname,x-stream-id,x-spos,sc-stream-bytes,cs-stream-bytes,x-file-size,x-file-length,x-ctx,x-comment
 log4j.appender.${com.wowza.wms.context.Application}_error.layout.OutputHeader=true
 log4j.appender.${com.wowza.wms.context.Application}_error.layout.QuoteFields=false
 log4j.appender.${com.wowza.wms.context.Application}_error.layout.Delimiter=tab

--- a/conf/example/log4j.properties
+++ b/conf/example/log4j.properties
@@ -17,7 +17,8 @@
 # To force UTF-8 encoding of log values add the following property to the appender definition (where [appender] is the name of the appender such as "stdout" or "R")
 #log4j.appender.[appender].encoding=UTF-8
 
-log4j.rootCategory=INFO, stdout, serverAccess, serverError
+#log4j.rootCategory=INFO, stdout, serverAccess, serverError
+log4j.rootCategory=INFO, stdout
 
 # Console appender
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender

--- a/conf/example/log4j.properties.orig
+++ b/conf/example/log4j.properties.orig
@@ -1,0 +1,156 @@
+log4j.rootCategory=INFO, stdout, serverAccess, serverError
+
+# The logging context is
+#log4j.logger.[vhost].[application].[appInstance]
+
+# Field list
+#date,time,tz,x-event,x-category,x-severity,x-status,x-ctx,x-comment,x-vhost,x-app,x-appinst,x-duration,s-ip,s-port,s-uri,c-ip,c-proto,c-referrer,c-user-agent,c-client-id,cs-bytes,sc-bytes,x-stream-id,x-spos,cs-stream-bytes,sc-stream-bytes,x-sname,x-sname-query,x-file-name,x-file-ext,x-file-size,x-file-length,x-suri,x-suri-stem,x-suri-query,cs-uri-stem,cs-uri-query
+
+# Category list
+#server,vhost,application,session,stream,rtsp
+
+# Event list
+#connect-pending,connect,disconnect,publish,unpublish,play,pause,setbuffertime,create,destroy,setstreamtype,unpause,seek,stop,record,recordstop,server-start,server-stop,vhost-start,vhost-stop,app-start,app-stop,comment,announce
+
+# To force UTF-8 encoding of log values add the following property to the appender definition (where [appender] is the name of the appender such as "stdout" or "R")
+#log4j.appender.[appender].encoding=UTF-8
+
+# Console appender
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=com.wowza.wms.logging.ECLFPatternLayout
+log4j.appender.stdout.layout.Fields=x-severity,x-category,x-event,x-ctx,x-comment
+log4j.appender.stdout.layout.OutputHeader=false
+log4j.appender.stdout.layout.QuoteFields=false
+log4j.appender.stdout.layout.Delimiter=space
+
+# Access appender
+log4j.appender.serverAccess=org.apache.log4j.DailyRollingFileAppender
+log4j.appender.serverAccess.encoding=UTF-8
+log4j.appender.serverAccess.DatePattern='.'yyyy-MM-dd
+log4j.appender.serverAccess.File=${com.wowza.wms.ConfigHome}/logs/wowzastreamingengine_access.log
+log4j.appender.serverAccess.layout=com.wowza.wms.logging.ECLFPatternLayout
+#log4j.appender.serverAccess.layout.Fields=x-severity,x-category,x-event;date,time,c-client-id,c-ip,c-port,cs-bytes,sc-bytes,x-duration,x-sname,x-stream-id,x-spos,sc-stream-bytes,cs-stream-bytes,x-file-size,x-file-length,x-ctx,x-comment
+log4j.appender.serverAccess.layout.Fields=date,time,tz,x-event,x-category,x-severity,x-status,x-ctx,x-comment,x-vhost,x-app,x-appinst,x-duration,s-ip,s-port,s-uri,c-ip,c-proto,c-referrer,c-user-agent,c-client-id,cs-bytes,sc-bytes,x-stream-id,x-spos,cs-stream-bytes,sc-stream-bytes,x-sname,x-sname-query,x-file-name,x-file-ext,x-file-size,x-file-length,x-suri,x-suri-stem,x-suri-query,cs-uri-stem,cs-uri-query
+log4j.appender.serverAccess.layout.OutputHeader=true
+log4j.appender.serverAccess.layout.QuoteFields=false
+log4j.appender.serverAccess.layout.Delimeter=tab
+
+# Access appender (UDP) - uncomment and add to rootCategory list on first line
+#log4j.appender.serverAccessUDP=com.wowza.wms.logging.UDPAppender
+#log4j.appender.serverAccessUDP.remoteHost=192.168.15.255
+#log4j.appender.serverAccessUDP.port=8881
+#log4j.appender.serverAccessUDP.layout=com.wowza.wms.logging.ECLFPatternLayout
+#log4j.appender.serverAccessUDP.layout.Fields=x-severity,x-category,x-event;date,time,c-client-id,c-ip,c-port,cs-bytes,sc-bytes,x-duration,x-sname,x-stream-id,x-spos,sc-stream-bytes,cs-stream-bytes,x-file-size,x-file-length,x-ctx,x-comment
+#log4j.appender.serverAccessUDP.layout.OutputHeader=true
+#log4j.appender.serverAccessUDP.layout.QuoteFields=false
+#log4j.appender.serverAccessUDP.layout.Delimeter=tab
+
+# Error appender
+log4j.appender.serverError=org.apache.log4j.DailyRollingFileAppender
+log4j.appender.serverError.encoding=UTF-8
+log4j.appender.serverError.DatePattern='.'yyyy-MM-dd
+log4j.appender.serverError.File=${com.wowza.wms.ConfigHome}/logs/wowzastreamingengine_error.log
+log4j.appender.serverError.layout=com.wowza.wms.logging.ECLFPatternLayout
+log4j.appender.serverError.layout.Fields=x-severity,x-category,x-event;date,time,c-client-id,c-ip,c-port,cs-bytes,sc-bytes,x-duration,x-sname,x-stream-id,x-spos,sc-stream-bytes,cs-stream-bytes,x-file-size,x-file-length,x-ctx,x-comment
+log4j.appender.serverError.layout.OutputHeader=true
+log4j.appender.serverError.layout.QuoteFields=false
+log4j.appender.serverError.layout.Delimeter=tab
+log4j.appender.serverError.Threshold=WARN
+
+# Statistics appender (to use this appender add "serverStats" to the list of appenders in the first line of this file)
+log4j.appender.serverStats=org.apache.log4j.DailyRollingFileAppender
+log4j.appender.serverStats.encoding=UTF-8
+log4j.appender.serverStats.DatePattern='.'yyyy-MM-dd
+log4j.appender.serverStats.File=${com.wowza.wms.ConfigHome}/logs/wowzastreamingengine_stats.log
+log4j.appender.serverStats.layout=com.wowza.wms.logging.ECLFPatternLayout
+log4j.appender.serverStats.layout.Fields=x-severity,x-category,x-event;date,time,c-client-id,c-ip,c-port,cs-bytes,sc-bytes,x-duration,x-sname,x-stream-id,x-spos,sc-stream-bytes,cs-stream-bytes,x-file-size,x-file-length,x-ctx,x-comment
+log4j.appender.serverStats.layout.OutputHeader=true
+log4j.appender.serverStats.layout.QuoteFields=false
+log4j.appender.serverStats.layout.Delimeter=tab
+log4j.appender.serverStats.layout.CategoryInclude=session,stream
+log4j.appender.serverStats.layout.EventExclude=comment
+
+# Below are logging definitions for dynamic log file generation on a per application basis.
+# To use these logging appender, uncomment each of the lines below. It will generate log files
+# using the following directory/file structure:
+#
+#   [install-dir]/logs/[vhost]/[application]/wowzastreamingengine_access.log
+#   [install-dir]/logs/[vhost]/[application]/wowzastreamingengine_error.log
+#   [install-dir]/logs/[vhost]/[application]/wowzastreamingengine_stats.log
+
+#### APPLICATION LEVEL LOGGING CONFIG - START ####
+#log4j.logger.${com.wowza.wms.context.VHost}.${com.wowza.wms.context.Application}=INFO, ${com.wowza.wms.context.VHost}_${com.wowza.wms.context.Application}_access, ${com.wowza.wms.context.VHost}_${com.wowza.wms.context.Application}_error, ${com.wowza.wms.context.VHost}_${com.wowza.wms.context.Application}_stats
+
+#log4j.appender.${com.wowza.wms.context.VHost}_${com.wowza.wms.context.Application}_access=org.apache.log4j.DailyRollingFileAppender
+#log4j.appender.${com.wowza.wms.context.VHost}_${com.wowza.wms.context.Application}_access.DatePattern='.'yyyy-MM-dd
+#log4j.appender.${com.wowza.wms.context.VHost}_${com.wowza.wms.context.Application}_access.File=${com.wowza.wms.ConfigHome}/logs/${com.wowza.wms.context.VHost}/${com.wowza.wms.context.Application}/wowzastreamingengine_access.log
+#log4j.appender.${com.wowza.wms.context.VHost}_${com.wowza.wms.context.Application}_access.layout=com.wowza.wms.logging.ECLFPatternLayout
+#log4j.appender.${com.wowza.wms.context.VHost}_${com.wowza.wms.context.Application}_access.layout.Fields=x-severity,x-category,x-event;date,time,c-client-id,c-ip,c-port,cs-bytes,sc-bytes,x-duration,x-sname,x-stream-id,x-spos,sc-stream-bytes,cs-stream-bytes,x-file-size,x-file-length,x-ctx,x-comment
+#log4j.appender.${com.wowza.wms.context.VHost}_${com.wowza.wms.context.Application}_access.layout.OutputHeader=true
+#log4j.appender.${com.wowza.wms.context.VHost}_${com.wowza.wms.context.Application}_access.layout.QuoteFields=false
+#log4j.appender.${com.wowza.wms.context.VHost}_${com.wowza.wms.context.Application}_access.layout.Delimeter=tab
+
+#log4j.appender.${com.wowza.wms.context.VHost}_${com.wowza.wms.context.Application}_error=org.apache.log4j.DailyRollingFileAppender
+#log4j.appender.${com.wowza.wms.context.VHost}_${com.wowza.wms.context.Application}_error.DatePattern='.'yyyy-MM-dd
+#log4j.appender.${com.wowza.wms.context.VHost}_${com.wowza.wms.context.Application}_error.File=${com.wowza.wms.ConfigHome}/logs/${com.wowza.wms.context.VHost}/${com.wowza.wms.context.Application}/wowzastreamingengine_error.log
+#log4j.appender.${com.wowza.wms.context.VHost}_${com.wowza.wms.context.Application}_error.layout=com.wowza.wms.logging.ECLFPatternLayout
+#log4j.appender.${com.wowza.wms.context.VHost}_${com.wowza.wms.context.Application}_error.layout.Fields=x-severity,x-category,x-event;date,time,c-client-id,c-ip,c-port,cs-bytes,sc-bytes,x-duration,x-sname,x-stream-id,x-spos,sc-stream-bytes,cs-stream-bytes,x-file-size,x-file-length,x-ctx,x-comment
+#log4j.appender.${com.wowza.wms.context.VHost}_${com.wowza.wms.context.Application}_error.layout.OutputHeader=true
+#log4j.appender.${com.wowza.wms.context.VHost}_${com.wowza.wms.context.Application}_error.layout.QuoteFields=false
+#log4j.appender.${com.wowza.wms.context.VHost}_${com.wowza.wms.context.Application}_error.layout.Delimeter=tab
+#log4j.appender.${com.wowza.wms.context.VHost}_${com.wowza.wms.context.Application}_error.Threshold=WARN
+
+#log4j.appender.${com.wowza.wms.context.VHost}_${com.wowza.wms.context.Application}_stats=org.apache.log4j.DailyRollingFileAppender
+#log4j.appender.${com.wowza.wms.context.VHost}_${com.wowza.wms.context.Application}_stats.DatePattern='.'yyyy-MM-dd
+#log4j.appender.${com.wowza.wms.context.VHost}_${com.wowza.wms.context.Application}_stats.File=${com.wowza.wms.ConfigHome}/logs/${com.wowza.wms.context.VHost}/${com.wowza.wms.context.Application}/wowzastreamingengine_stats.log
+#log4j.appender.${com.wowza.wms.context.VHost}_${com.wowza.wms.context.Application}_stats.layout=com.wowza.wms.logging.ECLFPatternLayout
+#log4j.appender.${com.wowza.wms.context.VHost}_${com.wowza.wms.context.Application}_stats.layout.Fields=x-severity,x-category,x-event;date,time,c-client-id,c-ip,c-port,cs-bytes,sc-bytes,x-duration,x-sname,x-stream-id,x-spos,sc-stream-bytes,cs-stream-bytes,x-file-size,x-file-length,x-ctx,x-comment
+#log4j.appender.${com.wowza.wms.context.VHost}_${com.wowza.wms.context.Application}_stats.layout.OutputHeader=true
+#log4j.appender.${com.wowza.wms.context.VHost}_${com.wowza.wms.context.Application}_stats.layout.QuoteFields=false
+#log4j.appender.${com.wowza.wms.context.VHost}_${com.wowza.wms.context.Application}_stats.layout.Delimeter=tab
+#log4j.appender.${com.wowza.wms.context.VHost}_${com.wowza.wms.context.Application}_stats.layout.CategoryInclude=session,stream
+#log4j.appender.${com.wowza.wms.context.VHost}_${com.wowza.wms.context.Application}_stats.layout.EventExclude=comment
+#### APPLICATION LEVEL LOGGING CONFIG - STOP ####
+
+
+# Below are logging definitions for dynamic log file generation on a per virtual host basis.
+# To use these logging appender, uncomment each of the lines below. It will generate log files
+# using the following directory/file structure:
+#
+#   [install-dir]/logs/[vhost]/wowzastreamingengine_access.log
+#   [install-dir]/logs/[vhost]/wowzastreamingengine_error.log
+#   [install-dir]/logs/[vhost]/wowzastreamingengine_stats.log
+
+#### VHOST LEVEL LOGGING CONFIG - START ####
+#log4j.logger.${com.wowza.wms.context.VHost}=INFO, ${com.wowza.wms.context.VHost}_access, ${com.wowza.wms.context.VHost}_error, ${com.wowza.wms.context.VHost}_stats
+
+#log4j.appender.${com.wowza.wms.context.VHost}_access=org.apache.log4j.DailyRollingFileAppender
+#log4j.appender.${com.wowza.wms.context.VHost}_access.DatePattern='.'yyyy-MM-dd
+#log4j.appender.${com.wowza.wms.context.VHost}_access.File=${com.wowza.wms.ConfigHome}/logs/${com.wowza.wms.context.VHost}/wowzastreamingengine_access.log
+#log4j.appender.${com.wowza.wms.context.VHost}_access.layout=com.wowza.wms.logging.ECLFPatternLayout
+#log4j.appender.${com.wowza.wms.context.VHost}_access.layout.Fields=x-severity,x-category,x-event;date,time,c-client-id,c-ip,c-port,cs-bytes,sc-bytes,x-duration,x-sname,x-stream-id,x-spos,sc-stream-bytes,cs-stream-bytes,x-file-size,x-file-length,x-ctx,x-comment
+#log4j.appender.${com.wowza.wms.context.VHost}_access.layout.OutputHeader=true
+#log4j.appender.${com.wowza.wms.context.VHost}_access.layout.QuoteFields=false
+#log4j.appender.${com.wowza.wms.context.VHost}_access.layout.Delimeter=tab
+
+#log4j.appender.${com.wowza.wms.context.VHost}_error=org.apache.log4j.DailyRollingFileAppender
+#log4j.appender.${com.wowza.wms.context.VHost}_error.DatePattern='.'yyyy-MM-dd
+#log4j.appender.${com.wowza.wms.context.VHost}_error.File=${com.wowza.wms.ConfigHome}/logs/${com.wowza.wms.context.VHost}/wowzastreamingengine_error.log
+#log4j.appender.${com.wowza.wms.context.VHost}_error.layout=com.wowza.wms.logging.ECLFPatternLayout
+#log4j.appender.${com.wowza.wms.context.VHost}_error.layout.Fields=x-severity,x-category,x-event;date,time,c-client-id,c-ip,c-port,cs-bytes,sc-bytes,x-duration,x-sname,x-stream-id,x-spos,sc-stream-bytes,cs-stream-bytes,x-file-size,x-file-length,x-ctx,x-comment
+#log4j.appender.${com.wowza.wms.context.VHost}_error.layout.OutputHeader=true
+#log4j.appender.${com.wowza.wms.context.VHost}_error.layout.QuoteFields=false
+#log4j.appender.${com.wowza.wms.context.VHost}_error.layout.Delimeter=tab
+#log4j.appender.${com.wowza.wms.context.VHost}_error.Threshold=WARN
+
+#log4j.appender.${com.wowza.wms.context.VHost}_stats=org.apache.log4j.DailyRollingFileAppender
+#log4j.appender.${com.wowza.wms.context.VHost}_stats.DatePattern='.'yyyy-MM-dd
+#log4j.appender.${com.wowza.wms.context.VHost}_stats.File=${com.wowza.wms.ConfigHome}/logs/${com.wowza.wms.context.VHost}/wowzastreamingengine_stats.log
+#log4j.appender.${com.wowza.wms.context.VHost}_stats.layout=com.wowza.wms.logging.ECLFPatternLayout
+#log4j.appender.${com.wowza.wms.context.VHost}_stats.layout.Fields=x-severity,x-category,x-event;date,time,c-client-id,c-ip,c-port,cs-bytes,sc-bytes,x-duration,x-sname,x-stream-id,x-spos,sc-stream-bytes,cs-stream-bytes,x-file-size,x-file-length,x-ctx,x-comment
+#log4j.appender.${com.wowza.wms.context.VHost}_stats.layout.OutputHeader=true
+#log4j.appender.${com.wowza.wms.context.VHost}_stats.layout.QuoteFields=false
+#log4j.appender.${com.wowza.wms.context.VHost}_stats.layout.Delimeter=tab
+#log4j.appender.${com.wowza.wms.context.VHost}_stats.layout.CategoryInclude=session,stream
+#log4j.appender.${com.wowza.wms.context.VHost}_stats.layout.EventExclude=comment
+#### VHOST LEVEL LOGGING CONFIG - STOP ####


### PR DESCRIPTION
Connects to #33

wanted to get these files committed for change tracking.

Note that log4j.properties is now in use on -dev, -stage and -prod wowza, and is doing (wowza) application level logging.  w00t!
