### PR TITLE
Log to file and leave log rotation to puppet

### DIFF
--- a/conf/example/log4j.properties
+++ b/conf/example/log4j.properties
@@ -30,6 +30,7 @@ log4j.appender.serverAccess.layout.Fields=date,time,x-app,x-severity,x-status,c-
 log4j.appender.serverAccess.layout.OutputHeader=true
 log4j.appender.serverAccess.layout.QuoteFields=false
 log4j.appender.serverAccess.layout.Delimiter=tab
+log4j.appender.serverAccess.Threshold=WARN
 
 # Error appender
 log4j.appender.serverError=org.apache.log4j.FileAppender

--- a/conf/example/log4j.properties
+++ b/conf/example/log4j.properties
@@ -22,9 +22,8 @@ log4j.appender.stdout.layout.QuoteFields=false
 log4j.appender.stdout.layout.Delimiter=space
 
 # Access appender
-log4j.appender.serverAccess=org.apache.log4j.DailyRollingFileAppender
+log4j.appender.serverAccess=org.apache.log4j.FileAppender
 log4j.appender.serverAccess.encoding=UTF-8
-log4j.appender.serverAccess.DatePattern='.'yyyy-MM-dd
 log4j.appender.serverAccess.File=${com.wowza.wms.ConfigHome}/logs/wowzastreamingengine_access.log
 log4j.appender.serverAccess.layout=com.wowza.wms.logging.ECLFPatternLayout
 log4j.appender.serverAccess.layout.Fields=date,time,x-app,x-severity,x-status,c-proto,x-category,x-event,x-ctx,x-comment,x-sname,x-file-name,x-file-ext,x-suri,c-ip,c-client-id,c-referrer,c-user-agent,s-uri,x-stream-id,x-file-size,x-file-length,sc-bytes,sc-stream-bytes,x-spos,x-duration
@@ -33,9 +32,8 @@ log4j.appender.serverAccess.layout.QuoteFields=false
 log4j.appender.serverAccess.layout.Delimiter=tab
 
 # Error appender
-log4j.appender.serverError=org.apache.log4j.DailyRollingFileAppender
+log4j.appender.serverError=org.apache.log4j.FileAppender
 log4j.appender.serverError.encoding=UTF-8
-log4j.appender.serverError.DatePattern='.'yyyy-MM-dd
 log4j.appender.serverError.File=${com.wowza.wms.ConfigHome}/logs/wowzastreamingengine_error.log
 log4j.appender.serverError.layout=com.wowza.wms.logging.ECLFPatternLayout
 log4j.appender.serverError.layout.Fields=date,time,x-app,x-severity,x-status,c-proto,x-category,x-event,x-ctx,x-comment,x-sname,x-file-name,x-file-ext,x-suri,c-ip,c-client-id,c-referrer,c-user-agent,s-uri,x-stream-id,x-file-size,x-file-length,sc-bytes,sc-stream-bytes,x-spos,x-duration
@@ -52,8 +50,7 @@ log4j.appender.serverError.Threshold=WARN
 log4j.logger.${com.wowza.wms.context.VHost}.${com.wowza.wms.context.Application}=INFO, ${com.wowza.wms.context.Application}_access, ${com.wowza.wms.context.Application}_error
 
 # Access appender
-log4j.appender.${com.wowza.wms.context.Application}_access=org.apache.log4j.DailyRollingFileAppender
-log4j.appender.${com.wowza.wms.context.Application}_access.DatePattern='.'yyyy-MM-dd
+log4j.appender.${com.wowza.wms.context.Application}_access=org.apache.log4j.FileAppender
 log4j.appender.${com.wowza.wms.context.Application}_access.encoding=UTF-8
 log4j.appender.${com.wowza.wms.context.Application}_access.File=${com.wowza.wms.ConfigHome}/logs/${com.wowza.wms.context.Application}/wowzastreamingengine_access.log
 log4j.appender.${com.wowza.wms.context.Application}_access.layout=com.wowza.wms.logging.ECLFPatternLayout
@@ -63,8 +60,7 @@ log4j.appender.${com.wowza.wms.context.Application}_access.layout.QuoteFields=fa
 log4j.appender.${com.wowza.wms.context.Application}_access.layout.Delimiter=tab
 
 # Error appender
-log4j.appender.${com.wowza.wms.context.Application}_error=org.apache.log4j.DailyRollingFileAppender
-log4j.appender.${com.wowza.wms.context.Application}_error.DatePattern='.'yyyy-MM-dd
+log4j.appender.${com.wowza.wms.context.Application}_error=org.apache.log4j.FileAppender
 log4j.appender.${com.wowza.wms.context.Application}_error.encoding=UTF-8
 log4j.appender.${com.wowza.wms.context.Application}_error.File=${com.wowza.wms.ConfigHome}/logs/${com.wowza.wms.context.Application}/wowzastreamingengine_error.log
 log4j.appender.${com.wowza.wms.context.Application}_error.layout=com.wowza.wms.logging.ECLFPatternLayout


### PR DESCRIPTION
In order to get the Wowza logs written to afs, it is better to let puppet handle the log rotation, as it will write the logs to afs as part of that rotation script.

I also set the root level logging threshold for the access log to WARN, as we will only care about serious events logged only at the root level (and not at the application level)

connects to sul-dlss/media#97
