### PR TITLE
[WIP] fix honeybadger config

### DIFF
--- a/conf/example/Application.xml
+++ b/conf/example/Application.xml
@@ -226,6 +226,16 @@
         <Value>2</Value>
         <Type>Integer</Type>
       </Property>
+      <Property>
+        <Name>HONEYBADGER_API_KEY</Name>
+        <Value>zyx987</Value>
+        <Type>String</Type>
+      </Property>
+      <Property>
+        <Name>ENV</Name>
+        <Value>example-environment</Value>
+        <Type>String</Type>
+      </Property>
     </Properties>
   </Application>
 </Root>

--- a/src/edu/stanford/dlss/wowza/SulEnvironment.java
+++ b/src/edu/stanford/dlss/wowza/SulEnvironment.java
@@ -1,9 +1,0 @@
-package edu.stanford.dlss.wowza;
-
-public class SulEnvironment
-{
-    public String getEnvironmentVariable(String var)
-    {
-        return System.getenv(var);
-    }
-}

--- a/src/edu/stanford/dlss/wowza/SulWowza.java
+++ b/src/edu/stanford/dlss/wowza/SulWowza.java
@@ -141,8 +141,36 @@ public class SulWowza extends ModuleBase
 
     // TODO:  this approach expects the properties to be set in Application.xml
     //   maybe that's good, or maybe we want to load a java properties file from our plugin jar itself?
+    //
+    // TL;DR:  Application.xml should contain the API key and the instance environment (e.g. stage, prod),
+    // in its <Properties> section.  the property names should be "HONEYBADGER_API_KEY" and "ENV", respective.
+    // see conf/example/Application.xml.
     public void initDefaultHoneybadgerConfigContext(IApplicationInstance appInstance)
     {
+        // this is maybe too much background for here and should prob go in a readme or devops doc, but for now...
+        // the StandardConfigContext constructor first initializes the instance with a DefaultsConfigContext
+        // by way of a super() call to its parent class constructor (BaseChainedConfigContext).  that sets
+        // the honeybadger API URL.  the StandardConfigContext constructor can also take a map of properties,
+        // from which it will override default property values based on expected field names.  in particular,
+        // it'll look for the environment name first in the "ENV" field, then in the "JAVA_ENV" field.  it'll
+        // look for the API key in the "HONEYBADGER_API_KEY" field, then in the "honeybadger.api_key"* field.
+        // since IApplicationInstance.getProperties() returns a subclass of Map (WMSProperties) containing properties
+        // set in Application.xml, we can just set the property names we care about in Application.xml and they'll get
+        // picked up automatically.
+        //
+        // see also:
+        //  https://github.com/honeybadger-io/honeybadger-java#advanced-configuration
+        //  https://github.com/honeybadger-io/honeybadger-java/blob/1.1.0/src/main/java/io/honeybadger/reporter/config/DefaultsConfigContext.java
+        //  https://github.com/honeybadger-io/honeybadger-java/blob/1.1.0/src/main/java/io/honeybadger/reporter/config/BaseChainedConfigContext.java
+        //  https://github.com/honeybadger-io/honeybadger-java/blob/1.1.0/src/main/java/io/honeybadger/reporter/config/StandardConfigContext.java
+        //  https://github.com/honeybadger-io/honeybadger-java/blob/1.1.0/src/main/java/io/honeybadger/reporter/config/MapConfigContext.java
+        //  http://www.wowza.com/resources/serverapi/com/wowza/wms/application/IApplicationInstance.html#getProperties()
+        //  http://www.wowza.com/resources/serverapi/com/wowza/wms/application/WMSProperties.html
+        //
+        // * note: i suspect we shouldn't use "honeybadger.api_key", because it appears that
+        // MapConfigContext.getHoneybadgerUrl() erroneously looks there first for the URL, so we
+        // should avoid confusing it, to be safe:
+        // https://github.com/honeybadger-io/honeybadger-java/blob/1.1.0/src/main/java/io/honeybadger/reporter/config/MapConfigContext.java#L113
         setHoneybadgerConfigContext(new StandardConfigContext(appInstance.getProperties()));
     }
 

--- a/src/edu/stanford/dlss/wowza/SulWowza.java
+++ b/src/edu/stanford/dlss/wowza/SulWowza.java
@@ -58,9 +58,7 @@ public class SulWowza extends ModuleBase
      * defined in the IModuleOnApp interface */
     public void onAppStart(IApplicationInstance appInstance)
     {
-        initHoneybadger();
-        registerUncaughtExceptionHandler();
-        initNoticeReporter();
+        initHoneybadger(appInstance);
         setStacksConnectionTimeout(appInstance);
         setStacksReadTimeout(appInstance);
         stacksTokenVerificationBaseUrl = getStacksUrl(appInstance);
@@ -151,13 +149,11 @@ public class SulWowza extends ModuleBase
      * Initalizes the Honeybadger error reporting tool. This is a public method so we can call
      * it from the tests. It's outside the constructor, since testing constructors with Mockito is a pain.
      */
-    public void initHoneybadger()
+    public void initHoneybadger(IApplicationInstance appInstance)
     {
-        if(environment == null)
-            environment = new SulEnvironment();
 
-        String apiKey = environment.getEnvironmentVariable(HONEYBADGER_API_KEY_ENV_VAR);
-        String honeybadgerEnv = environment.getEnvironmentVariable(HONEYBADGER_ENV_NAME_ENV_VAR);
+        String apiKey = appInstance.getProperties().getPropertyStr(HONEYBADGER_API_KEY_ENV_VAR);
+        String honeybadgerEnv = appInstance.getProperties().getPropertyStr(HONEYBADGER_ENV_NAME_ENV_VAR);
         if(apiKey == null)
         {
             getLogger().error(this.getClass().getSimpleName() + " unable to set up Honeybadger error reporting (missing API key environment variable?)");
@@ -174,6 +170,7 @@ public class SulWowza extends ModuleBase
             honeybadgerConfig.setApiKey(apiKey)
                              .setEnvironment(honeybadgerEnv)
                              .setApplicationPackage(this.getClass().getPackage().getName());
+            registerUncaughtExceptionHandler();
         }
     }
 
@@ -568,9 +565,14 @@ public class SulWowza extends ModuleBase
         HoneybadgerUncaughtExceptionHandler.registerAsUncaughtExceptionHandler(honeybadgerConfig);
     }
 
+    void setNoticeReporter(NoticeReporter noticeReporter)
+    {
+        this.noticeReporter = noticeReporter;
+    }
+
     void initNoticeReporter()
     {
-        noticeReporter = new HoneybadgerReporter(honeybadgerConfig);
+        setNoticeReporter(new HoneybadgerReporter(honeybadgerConfig));
     }
 
     NoticeReporter getNoticeReporter()

--- a/src/edu/stanford/dlss/wowza/SulWowza.java
+++ b/src/edu/stanford/dlss/wowza/SulWowza.java
@@ -40,19 +40,10 @@ public class SulWowza extends ModuleBase
     static int stacksReadTimeout;
     static NoticeReporter noticeReporter;
     StandardConfigContext honeybadgerConfig;
-    SulEnvironment environment;
 
 
     /** configuration is invalid if the stacks url is malformed */
     boolean invalidConfiguration = false;
-
-    public SulWowza()
-    {}
-
-    public SulWowza(SulEnvironment se)
-    {
-        environment = se;
-    }
 
     /** invoked when a Wowza application instance is started;
      * defined in the IModuleOnApp interface */

--- a/test/edu/stanford/dlss/wowza/TestParsingFromRequestInfo.java
+++ b/test/edu/stanford/dlss/wowza/TestParsingFromRequestInfo.java
@@ -17,7 +17,6 @@ public class TestParsingFromRequestInfo
     public void setUp()
     {
         testModule = new SulWowza();
-        testModule.initHoneybadger();
     }
 
     @Test

--- a/test/edu/stanford/dlss/wowza/TestSulWowza.java
+++ b/test/edu/stanford/dlss/wowza/TestSulWowza.java
@@ -8,6 +8,8 @@ import org.junit.*;
 
 import org.apache.log4j.*;
 
+import io.honeybadger.reporter.NoticeReporter;
+import io.honeybadger.reporter.HoneybadgerReporter;
 import io.honeybadger.reporter.HoneybadgerUncaughtExceptionHandler;
 
 import com.wowza.wms.amf.AMFDataList;
@@ -28,6 +30,7 @@ import java.util.Map;
 public class TestSulWowza
 {
     SulWowza testModule;
+    NoticeReporter mockNoticeReporter;
     final static String stacksToken = "encryptedStacksMediaToken";
     final static String queryStr = "stacks_token=" + stacksToken;
 
@@ -35,36 +38,52 @@ public class TestSulWowza
     public void setUp()
     {
         testModule = new SulWowza();
-        testModule.initHoneybadger();
+        mockNoticeReporter = mock(HoneybadgerReporter.class);
+        testModule.setNoticeReporter(mockNoticeReporter);
     }
 
     @Test
     public void onAppStart_calls_setStacksConnectionTimeout()
     {
+        WMSProperties mockProperties = mock(WMSProperties.class);
+        when(mockProperties.getPropertyStr(SulWowza.HONEYBADGER_API_KEY_ENV_VAR)).thenReturn("test_key");
+        when(mockProperties.getPropertyStr(SulWowza.HONEYBADGER_ENV_NAME_ENV_VAR)).thenReturn("test_env");
+
         SulWowza spyModule = spy(testModule);
         IApplicationInstance appInstanceMock = mock(IApplicationInstance.class);
-        spyModule.onAppStart(appInstanceMock);
+        when(appInstanceMock.getProperties()).thenReturn(mockProperties);
 
+        spyModule.onAppStart(appInstanceMock);
         verify(spyModule).setStacksConnectionTimeout(appInstanceMock);
     }
 
     @Test
     public void onAppStart_calls_setStacksReadTimeout()
     {
+        WMSProperties mockProperties = mock(WMSProperties.class);
+        when(mockProperties.getPropertyStr(SulWowza.HONEYBADGER_API_KEY_ENV_VAR)).thenReturn("test_key");
+        when(mockProperties.getPropertyStr(SulWowza.HONEYBADGER_ENV_NAME_ENV_VAR)).thenReturn("test_env");
+
         SulWowza spyModule = spy(testModule);
         IApplicationInstance appInstanceMock = mock(IApplicationInstance.class);
-        spyModule.onAppStart(appInstanceMock);
+        when(appInstanceMock.getProperties()).thenReturn(mockProperties);
 
+        spyModule.onAppStart(appInstanceMock);
         verify(spyModule).setStacksReadTimeout(appInstanceMock);
     }
 
     @Test
     public void onAppStart_calls_getStacksUrl()
     {
+        WMSProperties mockProperties = mock(WMSProperties.class);
+        when(mockProperties.getPropertyStr(SulWowza.HONEYBADGER_API_KEY_ENV_VAR)).thenReturn("test_key");
+        when(mockProperties.getPropertyStr(SulWowza.HONEYBADGER_ENV_NAME_ENV_VAR)).thenReturn("test_env");
+
         SulWowza spyModule = spy(testModule);
         IApplicationInstance appInstanceMock = mock(IApplicationInstance.class);
-        spyModule.onAppStart(appInstanceMock);
+        when(appInstanceMock.getProperties()).thenReturn(mockProperties);
 
+        spyModule.onAppStart(appInstanceMock);
         verify(spyModule).getStacksUrl(appInstanceMock);
     }
 
@@ -182,56 +201,75 @@ public class TestSulWowza
     @Test
     public void onAppStart_setsUpUncaughtExceptionHandler()
     {
+        WMSProperties mockProperties = mock(WMSProperties.class);
+        when(mockProperties.getPropertyStr(SulWowza.HONEYBADGER_API_KEY_ENV_VAR)).thenReturn("test_key");
+        when(mockProperties.getPropertyStr(SulWowza.HONEYBADGER_ENV_NAME_ENV_VAR)).thenReturn("test_env");
+
         SulWowza spyModule = spy(testModule);
         IApplicationInstance appInstanceMock = mock(IApplicationInstance.class);
-        spyModule.onAppStart(appInstanceMock);
+        when(appInstanceMock.getProperties()).thenReturn(mockProperties);
 
+        spyModule.onAppStart(appInstanceMock);
         verify(spyModule).registerUncaughtExceptionHandler();
     }
 
     @Test
     public void onAppStart_initializesHoneybadger()
     {
+        WMSProperties mockProperties = mock(WMSProperties.class);
+        when(mockProperties.getPropertyStr(SulWowza.HONEYBADGER_API_KEY_ENV_VAR)).thenReturn("test_key");
+        when(mockProperties.getPropertyStr(SulWowza.HONEYBADGER_ENV_NAME_ENV_VAR)).thenReturn("test_env");
+
         SulWowza spyModule = spy(testModule);
         IApplicationInstance appInstanceMock = mock(IApplicationInstance.class);
-        spyModule.onAppStart(appInstanceMock);
+        when(appInstanceMock.getProperties()).thenReturn(mockProperties);
 
-        verify(spyModule).initHoneybadger();
+        spyModule.onAppStart(appInstanceMock);
+        verify(spyModule).initHoneybadger(appInstanceMock);
     }
 
     @Test
     public void initHoneybadger_failsWithoutAPIKey()
     {
-        SulEnvironment mockSystem = mock(SulEnvironment.class);
-        when(mockSystem.getEnvironmentVariable(SulWowza.HONEYBADGER_API_KEY_ENV_VAR)).thenReturn(null);
-        when(mockSystem.getEnvironmentVariable(SulWowza.HONEYBADGER_ENV_NAME_ENV_VAR)).thenReturn("test_env");
+        WMSProperties mockProperties = mock(WMSProperties.class);
+        when(mockProperties.getPropertyStr(SulWowza.HONEYBADGER_API_KEY_ENV_VAR)).thenReturn(null);
+        when(mockProperties.getPropertyStr(SulWowza.HONEYBADGER_ENV_NAME_ENV_VAR)).thenReturn("test_env");
 
-        SulWowza localTestModule = new SulWowza(mockSystem);
-        localTestModule.initHoneybadger();
+        SulWowza localTestModule = new SulWowza();
+        IApplicationInstance appInstanceMock = mock(IApplicationInstance.class);
+        when(appInstanceMock.getProperties()).thenReturn(mockProperties);
+
+        localTestModule.initHoneybadger(appInstanceMock);
         assertTrue(localTestModule.invalidConfiguration);
     }
 
     @Test
     public void initHoneybadger_failsWithoutHoneybadgerEnv()
     {
-        SulEnvironment mockSystem = mock(SulEnvironment.class);
-        when(mockSystem.getEnvironmentVariable(SulWowza.HONEYBADGER_API_KEY_ENV_VAR)).thenReturn("abcd");
-        when(mockSystem.getEnvironmentVariable(SulWowza.HONEYBADGER_ENV_NAME_ENV_VAR)).thenReturn(null);
+        WMSProperties mockProperties = mock(WMSProperties.class);
+        when(mockProperties.getPropertyStr(SulWowza.HONEYBADGER_API_KEY_ENV_VAR)).thenReturn("abcd");
+        when(mockProperties.getPropertyStr(SulWowza.HONEYBADGER_ENV_NAME_ENV_VAR)).thenReturn(null);
 
-        SulWowza localTestModule = new SulWowza(mockSystem);
-        localTestModule.initHoneybadger();
+        SulWowza localTestModule = new SulWowza();
+        IApplicationInstance appInstanceMock = mock(IApplicationInstance.class);
+        when(appInstanceMock.getProperties()).thenReturn(mockProperties);
+
+        localTestModule.initHoneybadger(appInstanceMock);
         assertTrue(localTestModule.invalidConfiguration);
     }
 
     @Test
     public void initHoneybadger_succeedsWithAPIKeyAndHoneybadgerEnv()
     {
-        SulEnvironment mockSystem = mock(SulEnvironment.class);
-        when(mockSystem.getEnvironmentVariable(SulWowza.HONEYBADGER_API_KEY_ENV_VAR)).thenReturn("abcd");
-        when(mockSystem.getEnvironmentVariable(SulWowza.HONEYBADGER_ENV_NAME_ENV_VAR)).thenReturn("test_env");
+        WMSProperties mockProperties = mock(WMSProperties.class);
+        when(mockProperties.getPropertyStr(SulWowza.HONEYBADGER_API_KEY_ENV_VAR)).thenReturn("abcd");
+        when(mockProperties.getPropertyStr(SulWowza.HONEYBADGER_ENV_NAME_ENV_VAR)).thenReturn("test_env");
 
-        SulWowza localTestModule = new SulWowza(mockSystem);
-        localTestModule.initHoneybadger();
+        SulWowza localTestModule = new SulWowza();
+        IApplicationInstance appInstanceMock = mock(IApplicationInstance.class);
+        when(appInstanceMock.getProperties()).thenReturn(mockProperties);
+
+        localTestModule.initHoneybadger(appInstanceMock);
         assertFalse(localTestModule.invalidConfiguration);
     }
 
@@ -239,6 +277,14 @@ public class TestSulWowza
     @Test
     public void registerUncaughtExceptionHandler_registersHoneybadger()
     {
+        WMSProperties mockProperties = mock(WMSProperties.class);
+        when(mockProperties.getPropertyStr(SulWowza.HONEYBADGER_API_KEY_ENV_VAR)).thenReturn("abcd");
+        when(mockProperties.getPropertyStr(SulWowza.HONEYBADGER_ENV_NAME_ENV_VAR)).thenReturn("test_env");
+
+        IApplicationInstance appInstanceMock = mock(IApplicationInstance.class);
+        when(appInstanceMock.getProperties()).thenReturn(mockProperties);
+
+        testModule.initHoneybadger(appInstanceMock);
         testModule.registerUncaughtExceptionHandler();
 
         HoneybadgerUncaughtExceptionHandler curThreadUncaughtExceptionHandler =
@@ -525,7 +571,7 @@ public class TestSulWowza
         when(sessionMock.getQueryStr()).thenReturn(queryStr);
         when(sessionMock.getStreamName()).thenReturn(streamName);
         SulWowza spyModule = spy(testModule);
-        when(spyModule.verifyStacksToken(stacksToken, druid, filename, userIp)).thenReturn(true);
+        doReturn(true).when(spyModule).verifyStacksToken(stacksToken, druid, filename, userIp);
 
         spyModule.authorizeSession(sessionMock);
         verify(sessionMock).acceptSession();
@@ -545,7 +591,7 @@ public class TestSulWowza
         when(sessionMock.getQueryStr()).thenReturn(queryStr);
         when(sessionMock.getStreamName()).thenReturn(streamName);
         SulWowza spyModule = spy(testModule);
-        when(spyModule.verifyStacksToken(stacksToken, druid, filename, userIp)).thenReturn(false);
+        doReturn(false).when(spyModule).verifyStacksToken(stacksToken, druid, filename, userIp);
 
         spyModule.authorizeSession(sessionMock);
         verify(sessionMock).rejectSession();
@@ -702,7 +748,7 @@ public class TestSulWowza
         when(spyModule.validateStreamName(streamName)).thenReturn(true);
         when(spyModule.getDruid(streamName)).thenReturn(druid);
         when(spyModule.getFilename(streamName)).thenReturn(filename);
-        when(spyModule.verifyStacksToken(token, druid, filename, userIp)).thenReturn(true);
+        doReturn(true).when(spyModule).verifyStacksToken(token, druid, filename, userIp);
 
         assertEquals(true, spyModule.authorizePlay(queryString, userIp, streamName));
     }
@@ -724,7 +770,7 @@ public class TestSulWowza
         when(spyModule.validateStreamName(streamName)).thenReturn(true);
         when(spyModule.getDruid(streamName)).thenReturn(druid);
         when(spyModule.getFilename(streamName)).thenReturn(filename);
-        when(spyModule.verifyStacksToken(token, druid, filename, userIp)).thenReturn(false);
+        doReturn(false).when(spyModule).verifyStacksToken(token, druid, filename, userIp);
 
         assertEquals(false, spyModule.authorizePlay(queryString, userIp, streamName));
     }
@@ -739,7 +785,7 @@ public class TestSulWowza
 
         SulWowza spyModule = spy(testModule);
         when(spyModule.getStacksToken(queryString)).thenReturn(token);
-        when(spyModule.validateUserIp("1")).thenReturn(true);
+        doReturn(true).when(spyModule).validateUserIp("1");
 
         spyModule.authorizePlay(queryString, userIp, streamName);
         verify(spyModule).validateStacksToken(token);

--- a/test/edu/stanford/dlss/wowza/TestValidationMethods.java
+++ b/test/edu/stanford/dlss/wowza/TestValidationMethods.java
@@ -17,7 +17,6 @@ public class TestValidationMethods
     public void setUp()
     {
         testModule = new SulWowza();
-        testModule.initHoneybadger();
     }
 
     @Test

--- a/test/edu/stanford/dlss/wowza/TestVerifyStacksToken.java
+++ b/test/edu/stanford/dlss/wowza/TestVerifyStacksToken.java
@@ -26,7 +26,6 @@ public class TestVerifyStacksToken
     public void setUp()
     {
         testModule = new SulWowza();
-        testModule.initHoneybadger();
     }
 
     @Test


### PR DESCRIPTION
* the overall idea is that honeybadger settings will be obtained from Application.xml properties, as is done with stacks timeout and such.
  * as such, the honeybadger API key and env name properties will have to be added to the Application.xml definition in puppet.  we should remove the equivalent environment variables, since we won't be using those.
* the switch in approach is because it turns out it's a pain to read environment variables in the wowza plugin.  you can't just do `System.getenv()`:  i suspect this is a JVM security manager restriction or something, but you have to write another wowza module that implements `IServerNotify` and gets compiled into a JAR and enabled in Server.xml.  that seemed like a lot of new configuration and testing when we can already put private custom settings in Application.xml.  the only reason for using environment variables initially was that the Honeybadger docs made it seem like that'd be the easiest way for its config machinery to pick up settings (see https://github.com/honeybadger-io/honeybadger-java#advanced-configuration).
* this works fine in the unit tests, but since the key for my dev instance of wowza has expired, i can't actually test it.  forgetting to test this with the actual wowza server (and relying on the unit tests) is what led to this unexpectedly breaking upon deployment last time, so this should definitely be tested for real before it's actually tagged and built and deployed for real.
* you'll notice some use of `doReturn(...).when(spyModule).method()`, instead of the usual `when(spyModule.method()).thenReturn(...)`.  this is because by default, the latter approach will call out to the actual method on the `spyModule` instance, whereas the `doReturn` approach will just return the mock result w/o calling the underlying method.  in the cases where `doReturn` was used, calling out to the actual method caused errors, and was running code that wasn't the point of the test in question anyway.

so, if this looks like a reasonable approach, i think this is the TODO list:
* tweak whatever's unsatisfactory with this PR in terms of how the code reads.
* test w/ an actual running wowza server and make sure that it picks up the settings from Application.xml, or logs the right errors if they aren't present.
* add the Application.xml settings in a puppet PR. (on prod only, since we probably don't want alerts for the staging environment)
* update the `conf/version` file, tag the new version.
* build the new version in jenkins.
* puppet PR to specify the new version of the plugin for deployment.
* add the Honeybadger Java API JAR file to Puppet, so it can get deployed to Wowza's `lib/` directory together with the dlss-wowza jar file (on prod only, since we probably don't want alerts for the staging environment) - `honeybadger-java-1.1.0.jar`

since we're so close to winter break, i'd propose holding off on the actual deployment even if this all looks fine as-is and has no problems with testing, though i suspect there will be feedback on this and a possible lack of time to deploy and test anyway.  still, it'd be nice to get feedback on what's here.

sorry that this seemingly simple error reporting implementation has become a bit of a quagmire!