### PR TITLE
Skip validating the stacks token on SulWowza

### DIFF
--- a/src/edu/stanford/dlss/wowza/SulWowza.java
+++ b/src/edu/stanford/dlss/wowza/SulWowza.java
@@ -276,7 +276,7 @@ public class SulWowza extends ModuleBase
         getLogger().debug(this.getClass().getSimpleName() + " userIp: " + userIp);
         String streamName = httpSession.getStreamName();
         getLogger().debug(this.getClass().getSimpleName() + " streamName: " + streamName);
-        if (validateStacksToken(stacksToken) && validateUserIp(userIp) && validateStreamName(streamName))
+        if (validateUserIp(userIp) && validateStreamName(streamName))
         {
             String druid = getDruid(streamName);
             String filename = getFilename(streamName);
@@ -293,7 +293,7 @@ public class SulWowza extends ModuleBase
     boolean authorizePlay(String queryStr, String userIp, String streamName)
     {
         String stacksToken = getStacksToken(queryStr);
-        if (validateStacksToken(stacksToken) && validateUserIp(userIp) && validateStreamName(streamName))
+        if (validateUserIp(userIp) && validateStreamName(streamName))
         {
             String druid = getDruid(streamName);
             String filename = getFilename(streamName);
@@ -331,22 +331,6 @@ public class SulWowza extends ModuleBase
                     return param.getValue();
         }
         return null;
-    }
-
-    /** stacksToken is created by rails encryption in digital_stacks_rails app;
-     *  we have chosen a min length of 10 here as a "safe" minimum length */
-    private static final int MIN_STACKS_TOKEN_LENGTH = 10;
-
-    boolean validateStacksToken(String stacksToken)
-    {
-        if (stacksToken != null && stacksToken.length() > MIN_STACKS_TOKEN_LENGTH)
-            return true;
-        else
-        {
-            getLogger().error(this.getClass().getSimpleName() + ": stacksToken missing or implausibly short" +
-                                (stacksToken == null ? "" : ": " + stacksToken));
-            return false;
-        }
     }
 
     boolean isValidInetAddr(String inetAddress)
@@ -447,7 +431,7 @@ public class SulWowza extends ModuleBase
     /** Assumption: stacksToken, druid, userIp and filename are all reasonable values (non-null, not empty, etc.) */
     URL getVerifyStacksTokenUrl(String stacksToken, String druid, String filename, String userIp)
     {
-        String queryStr = "stacks_token=" + escapeFormParam(stacksToken) + "&user_ip=" + escapeFormParam(userIp);
+        String queryStr = "stacks_token=" + escapeFormParam(stacksToken == null ? "" : stacksToken) + "&user_ip=" + escapeFormParam(userIp);
         String fullUrl = stacksTokenVerificationBaseUrl + "/media/" +
                         escapePathSegment(druid) + "/" + escapePathSegment(filename) +
                         "/verify_token?" + queryStr;

--- a/test/edu/stanford/dlss/wowza/TestSulWowza.java
+++ b/test/edu/stanford/dlss/wowza/TestSulWowza.java
@@ -562,17 +562,6 @@ public class TestSulWowza
     }
 
     @Test
-    public void authorizeSession_validatesStacksToken()
-    {
-        IHTTPStreamerSession sessionMock = mock(IHTTPStreamerSession.class);
-        when(sessionMock.getQueryStr()).thenReturn(queryStr);
-        SulWowza spyModule = spy(testModule);
-
-        spyModule.authorizeSession(sessionMock);
-        verify(spyModule).validateStacksToken(stacksToken);
-    }
-
-    @Test
     public void authorizeSession_getsUserIp()
     {
         IHTTPStreamerSession sessionMock = mock(IHTTPStreamerSession.class);
@@ -697,7 +686,6 @@ public class TestSulWowza
         SulWowza spyModule = spy(testModule);
 
         when(spyModule.getStacksToken(queryString)).thenReturn(token);
-        when(spyModule.validateStacksToken(token)).thenReturn(true);
         when(spyModule.validateUserIp(userIp)).thenReturn(true);
         when(spyModule.validateStreamName(streamName)).thenReturn(true);
         when(spyModule.getDruid(streamName)).thenReturn(druid);
@@ -719,7 +707,6 @@ public class TestSulWowza
         SulWowza spyModule = spy(testModule);
 
         when(spyModule.getStacksToken(queryString)).thenReturn(token);
-        when(spyModule.validateStacksToken(token)).thenReturn(true);
         when(spyModule.validateUserIp(userIp)).thenReturn(true);
         when(spyModule.validateStreamName(streamName)).thenReturn(true);
         when(spyModule.getDruid(streamName)).thenReturn(druid);
@@ -727,22 +714,6 @@ public class TestSulWowza
         when(spyModule.verifyStacksToken(token, druid, filename, userIp)).thenReturn(false);
 
         assertEquals(false, spyModule.authorizePlay(queryString, userIp, streamName));
-    }
-
-    @Test
-    public void authorizePlay_validatesStacksToken()
-    {
-        String queryString = "query";
-        String userIp = "1.1.1.1";
-        String streamName = "stream.mp4";
-        String token = "abcd";
-
-        SulWowza spyModule = spy(testModule);
-        when(spyModule.getStacksToken(queryString)).thenReturn(token);
-        when(spyModule.validateUserIp("1")).thenReturn(true);
-
-        spyModule.authorizePlay(queryString, userIp, streamName);
-        verify(spyModule).validateStacksToken(token);
     }
 
     @Test
@@ -755,7 +726,6 @@ public class TestSulWowza
 
         SulWowza spyModule = spy(testModule);
         when(spyModule.getStacksToken(queryString)).thenReturn(token);
-        when(spyModule.validateStacksToken(token)).thenReturn(true);
 
         spyModule.authorizePlay(queryString, userIp, streamName);
         verify(spyModule).validateUserIp(userIp);
@@ -771,7 +741,6 @@ public class TestSulWowza
 
         SulWowza spyModule = spy(testModule);
         when(spyModule.getStacksToken(queryString)).thenReturn(token);
-        when(spyModule.validateStacksToken(token)).thenReturn(true);
         when(spyModule.validateUserIp(userIp)).thenReturn(true);
 
         spyModule.authorizePlay(queryString, userIp, streamName);
@@ -788,7 +757,6 @@ public class TestSulWowza
 
         SulWowza spyModule = spy(testModule);
         when(spyModule.getStacksToken(queryString)).thenReturn(token);
-        when(spyModule.validateStacksToken(token)).thenReturn(true);
         when(spyModule.validateUserIp(userIp)).thenReturn(true);
         when(spyModule.validateStreamName(streamName)).thenReturn(true);
         when(spyModule.getDruid(streamName)).thenReturn(null);
@@ -807,7 +775,6 @@ public class TestSulWowza
 
         SulWowza spyModule = spy(testModule);
         when(spyModule.getStacksToken(queryString)).thenReturn(token);
-        when(spyModule.validateStacksToken(token)).thenReturn(true);
         when(spyModule.validateUserIp(userIp)).thenReturn(true);
         when(spyModule.validateStreamName(streamName)).thenReturn(true);
         when(spyModule.getFilename(streamName)).thenReturn(null);
@@ -837,7 +804,6 @@ public class TestSulWowza
         String token = "abcd";
         SulWowza spyModule = spy(testModule);
         when(spyModule.getStacksToken(queryString)).thenReturn(token);
-        when(spyModule.validateStacksToken(token)).thenReturn(true);
         when(spyModule.validateUserIp(userIp)).thenReturn(true);
         when(spyModule.validateStreamName(streamName)).thenReturn(true);
 
@@ -854,7 +820,6 @@ public class TestSulWowza
         String token = "abcd";
         SulWowza spyModule = spy(testModule);
         when(spyModule.getStacksToken(queryString)).thenReturn(token);
-        when(spyModule.validateStacksToken(token)).thenReturn(true);
         when(spyModule.validateUserIp(userIp)).thenReturn(true);
         when(spyModule.validateStreamName(streamName)).thenReturn(true);
 

--- a/test/edu/stanford/dlss/wowza/TestVerifyStacksToken.java
+++ b/test/edu/stanford/dlss/wowza/TestVerifyStacksToken.java
@@ -126,6 +126,27 @@ public class TestVerifyStacksToken
     }
 
     @Test
+    public void verifyTokenAgainstStacksService_missingStacksToken()
+    {
+        WMSProperties mockProperties = mock(WMSProperties.class);
+        when(mockProperties.getPropertyStr(anyString(), anyString())).thenReturn(SulWowza.DEFAULT_STACKS_TOKEN_VERIFICATION_BASEURL);
+        IApplicationInstance appInstanceMock = mock(IApplicationInstance.class);
+        when(appInstanceMock.getProperties()).thenReturn(mockProperties);
+        testModule.onAppStart(appInstanceMock);
+        String druid = "oo000oo0000";
+        String filename = "filename.ext";
+        String userIp = "0.0.0.0";
+        String expPath = "/media/" + druid + "/" + filename + "/verify_token";
+        String stacksToken = null;
+        // specifically list the expected encodings, as we've run into trouble with encoding methods that were encoding in unexpected ways
+        String expQueryStr = "?stacks_token=&user_ip=" + userIp;
+        String expUrlStr = SulWowza.DEFAULT_STACKS_TOKEN_VERIFICATION_BASEURL + expPath + expQueryStr;
+
+        URL resultUrl = testModule.getVerifyStacksTokenUrl(stacksToken, druid, filename, userIp);
+        assertEquals(expUrlStr, resultUrl.toString());
+    }
+
+    @Test
     /** expect it to return null and log an error message */
     public void getVerifyStacksTokenUrl_malformedUrl()
     {


### PR DESCRIPTION
Let the stacks server handle that logic. This will allow stacks to decide whether or not to allow requests without tokens (which i think we could allow for world accessible streams, which would allow 3rd party players to stream that content)

Part of https://github.com/sul-dlss/media/issues/145

🤷 