### PR TITLE
[WIP] Fix Jenkins build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
 
         // make extra sure that no stale build artifacts are confounding things -- can revisit if builds are
         // unpleasantly slow
-        sh 'JAVA_OPTS= ./gradlew --no-build-cache --no-configuration-cache clean check'
+        sh 'JAVA_OPTS= JDK_JAVA_OPTIONS= ./gradlew --no-build-cache --no-configuration-cache clean check'
       }
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,19 @@ pipeline {
 
     stage('Test') {
       steps {
-        sh 'JAVA_OPTS= ./gradlew clean check'
+        withEnv(["JAVA_HOME=/home/$USER/openjdk21/jdk-21.0.1", "PATH=$JAVA_HOME/bin:$PATH"]) {
+          sh 'printenv | sort'
+          sh 'java -version' // print the java version being used, to aid in debugging build issues
+
+          // if the build breaks, and it's necessary to temporarily pin to a known working gradle
+          // version, can do e.g. --gradle-version=8.4
+          sh 'JAVA_OPTS= ./gradlew wrapper --gradle-version=latest --distribution-type=bin'
+          sh './gradlew --version' // print some basic gradle info, to aid in debugging build issues
+
+          // make extra sure that no stale build artifacts are confounding things -- can revisit if builds are
+          // unpleasantly slow
+          sh 'JAVA_OPTS= ./gradlew --no-build-cache --no-configuration-cache clean check'
+        }
       }
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,19 +15,17 @@ pipeline {
 
     stage('Test') {
       steps {
-        withEnv(["JAVA_HOME=/home/$USER/openjdk21/jdk-21.0.1", "PATH=$JAVA_HOME/bin:$PATH"]) {
-          sh 'printenv | sort'
-          sh 'java -version' // print the java version being used, to aid in debugging build issues
+        sh 'printenv | sort'
+        sh 'java -version' // print the java version being used, to aid in debugging build issues
 
-          // if the build breaks, and it's necessary to temporarily pin to a known working gradle
-          // version, can do e.g. --gradle-version=8.4
-          sh 'JAVA_OPTS= ./gradlew wrapper --gradle-version=latest --distribution-type=bin'
-          sh './gradlew --version' // print some basic gradle info, to aid in debugging build issues
+        // if the build breaks, and it's necessary to temporarily pin to a known working gradle
+        // version, can do e.g. --gradle-version=8.4
+        sh 'JAVA_OPTS= ./gradlew wrapper --gradle-version=latest --distribution-type=bin'
+        sh './gradlew --version' // print some basic gradle info, to aid in debugging build issues
 
-          // make extra sure that no stale build artifacts are confounding things -- can revisit if builds are
-          // unpleasantly slow
-          sh 'JAVA_OPTS= ./gradlew --no-build-cache --no-configuration-cache clean check'
-        }
+        // make extra sure that no stale build artifacts are confounding things -- can revisit if builds are
+        // unpleasantly slow
+        sh 'JAVA_OPTS= ./gradlew --no-build-cache --no-configuration-cache clean check'
       }
     }
 


### PR DESCRIPTION
## Why was this change made?

fix the build, include a JAR file that supports upgrading `gradlew` (omitted accidentally in #65).

i think the crux of the build fix is the upgraded JVM.  in this PR it's a hacky one off installation of OpenJDK 21 in the home dir of the user running the build.  in my case on my laptop an old OpenJDK 16 worked.  i actually noticed, from the env var printout in the jenkins logs for this PR's successful build, `$JAVA_HOME` got OpenJDK 21, but `$PATH` didn't actually get overridden, and the actual java binary in use according to `java -version` was OpenJDK 11.  so it seems that the real heart of the fix for the reflection error mentioned in #60 is the use of later supporting java libraries? 🤷  (i didn't see `CLASSPATH` defined in the env vars)

## How was this change tested?

throw stuff at CI till it goes ✅ 

## Which documentation and/or configurations were updated?

`Jenkinsfile`, `build.gradle`

## TODO
- [ ] squash commits
- [x] `build.gradle`: remove the commented out `with` cruft, or back out of the switch to `dependsOn`.  i'm inclined to do the former because: the change was motivated by an error that @aaron-collier and i each ran into on our laptops when building earlier this afternoon.  the switch to `depenedsOn` fixed it for me, but even if i go back to just using `with`, i can no longer reproduce the error.  still, i can't find any documentation anymore on `with`, but i can for `dependsOn`, so i suspect this change would get us off an old approach anyway? 🤷 
  - discussed w/ @aaron-collier just now, we're both inclined to switch to `dependsOn` since we can find documentation for that, but not for `with`.
- [ ] work with ops to upgrade the jenkins server's java installation to 21, or if that would break other things, to install something like jenv on the jenkins server so that we can manage multiple java versions more easily.  _(in progress: https://github.com/sul-dlss/operations-tasks/issues/3545)_
- [ ] once JDK 21 is available on the jenkins box, remove the env var overrides from `Jenkinsfile` but leave the debugging output.  add `jenv` invocations to switch to JDK 21 if need be (or otherwise update env var overrides as needed if java on jenkins box isn't globally upgraded).
- [x] leave the `--no-build-cache` and `--no-configuration-cache` flags?
  - let's leave for now, and if the builds are unpleasantly slow we can revisit
- [x] instead of specifying `--gradle-version=8.4`, we could also specify `--gradle-version=latest`
  - @aaron-collier and i discussed, and we're inclined to use the rule of thumb we use elsewhere in the portfolio: update to the latest if possible, and work backwards to pin on a working version if that breaks the build and we can't fix the build on `latest` in a timely manner.  will leave a comment in `Jenkinsfile` explaining that a specific version is selectable.
- [ ] take this out of draft
